### PR TITLE
Migrate Affine and Arith passes to tablegen

### DIFF
--- a/lib/Transform/Affine/AffineFullUnroll.cpp
+++ b/lib/Transform/Affine/AffineFullUnroll.cpp
@@ -1,49 +1,32 @@
 #include "lib/Transform/Affine/AffineFullUnroll.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/include/mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace tutorial {
 
+#define GEN_PASS_DEF_AFFINEFULLUNROLL
+#include "lib/Transform/Affine/Passes.h.inc"
+
 using mlir::affine::AffineForOp;
 using mlir::affine::loopUnrollFull;
 
 // A pass that manually walks the IR
-void AffineFullUnrollPass::runOnOperation() {
-  getOperation().walk([&](AffineForOp op) {
-    if (failed(loopUnrollFull(op))) {
-      op.emitError("unrolling failed");
-      signalPassFailure();
-    }
-  });
-}
+struct AffineFullUnroll : impl::AffineFullUnrollBase<AffineFullUnroll> {
+  using AffineFullUnrollBase::AffineFullUnrollBase;
 
-// A pattern that matches on AffineForOp and unrolls it.
-struct AffineFullUnrollPattern :
-  public OpRewritePattern<AffineForOp> {
-  AffineFullUnrollPattern(mlir::MLIRContext *context)
-      : OpRewritePattern<AffineForOp>(context, /*benefit=*/1) {}
-
-  LogicalResult matchAndRewrite(AffineForOp op,
-                                PatternRewriter &rewriter) const override {
-    // This is technically not allowed, since in a RewritePattern all
-    // modifications to the IR are supposed to go through the `rewriter` arg,
-    // but it works for our limited test cases.
-    return loopUnrollFull(op);
+  void runOnOperation() {
+    getOperation()->walk([&](AffineForOp op) {
+      if (failed(loopUnrollFull(op))) {
+        op.emitError("unrolling failed");
+        signalPassFailure();
+      }
+    });
   }
 };
 
-// A pass that invokes the pattern rewrite engine.
-void AffineFullUnrollPassAsPatternRewrite::runOnOperation() {
-  mlir::RewritePatternSet patterns(&getContext());
-  patterns.add<AffineFullUnrollPattern>(&getContext());
-  // One could use GreedyRewriteConfig here to slightly tweak the behavior of
-  // the pattern application.
-  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
-}
+
 
 } // namespace tutorial
 } // namespace mlir

--- a/lib/Transform/Affine/AffineFullUnroll.h
+++ b/lib/Transform/Affine/AffineFullUnroll.h
@@ -1,41 +1,15 @@
 #ifndef LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
 #define LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
 
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/include/mlir/Pass/Pass.h"
+#include "mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace tutorial {
 
-class AffineFullUnrollPass
-    : public PassWrapper<AffineFullUnrollPass,
-                         OperationPass<mlir::func::FuncOp>> {
-private:
-  void runOnOperation() override;
+#define GEN_PASS_DECL_AFFINEFULLUNROLL
+#include "lib/Transform/Affine/Passes.h.inc"
 
-  StringRef getArgument() const final { return "affine-full-unroll"; }
+}  // namespace tutorial
+}  // namespace mlir
 
-  StringRef getDescription() const final {
-    return "Fully unroll all affine loops";
-  }
-};
-
-class AffineFullUnrollPassAsPatternRewrite
-    : public PassWrapper<AffineFullUnrollPassAsPatternRewrite,
-                         OperationPass<mlir::func::FuncOp>> {
-private:
-  void runOnOperation() override;
-
-  StringRef getArgument() const final { return "affine-full-unroll-rewrite"; }
-
-  StringRef getDescription() const final {
-    return "Fully unroll all affine loops using pattern rewrite engine";
-  }
-};
-
-
-} // namespace tutorial
-} // namespace mlir
-
-#endif // LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
+#endif  // LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_

--- a/lib/Transform/Affine/AffineFullUnrollPatternRewrite.cpp
+++ b/lib/Transform/Affine/AffineFullUnrollPatternRewrite.cpp
@@ -1,0 +1,45 @@
+#include "lib/Transform/Affine/AffineFullUnrollPatternRewrite.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/LoopUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/include/mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace tutorial {
+
+#define GEN_PASS_DEF_AFFINEFULLUNROLLPATTERNREWRITE
+#include "lib/Transform/Affine/Passes.h.inc"
+
+using mlir::affine::AffineForOp;
+using mlir::affine::loopUnrollFull;
+
+// A pattern that matches on AffineForOp and unrolls it.
+struct AffineFullUnrollPattern : public OpRewritePattern<AffineForOp> {
+  AffineFullUnrollPattern(mlir::MLIRContext *context)
+      : OpRewritePattern<AffineForOp>(context, /*benefit=*/1) {}
+
+  LogicalResult matchAndRewrite(AffineForOp op,
+                                PatternRewriter &rewriter) const override {
+    // This is technically not allowed, since in a RewritePattern all
+    // modifications to the IR are supposed to go through the `rewriter` arg,
+    // but it works for our limited test cases.
+    return loopUnrollFull(op);
+  }
+};
+
+// A pass that invokes the pattern rewrite engine.
+struct AffineFullUnrollPatternRewrite
+    : impl::AffineFullUnrollPatternRewriteBase<AffineFullUnrollPatternRewrite> {
+  using AffineFullUnrollPatternRewriteBase::AffineFullUnrollPatternRewriteBase;
+  void runOnOperation() {
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<AffineFullUnrollPattern>(&getContext());
+    // One could use GreedyRewriteConfig here to slightly tweak the behavior of
+    // the pattern application.
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace tutorial
+} // namespace mlir

--- a/lib/Transform/Affine/AffineFullUnrollPatternRewrite.h
+++ b/lib/Transform/Affine/AffineFullUnrollPatternRewrite.h
@@ -1,0 +1,15 @@
+#ifndef LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLLPATTERNREWRITE_H_
+#define LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLLPATTERNREWRITE_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace tutorial {
+
+#define GEN_PASS_DECL_AFFINEFULLUNROLLPATTERNREWRITE
+#include "lib/Transform/Affine/Passes.h.inc"
+
+}  // namespace tutorial
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLLPATTERNREWRITE_H_

--- a/lib/Transform/Affine/BUILD
+++ b/lib/Transform/Affine/BUILD
@@ -32,12 +32,43 @@ gentbl_cc_library(
 cc_library(
     name = "AffineFullUnroll",
     srcs = ["AffineFullUnroll.cpp"],
-    hdrs = ["AffineFullUnroll.h"],
+    hdrs = [
+        "AffineFullUnroll.h",
+        "Passes.h",
+    ],
     deps = [
+        ":pass_inc_gen",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "AffineFullUnrollPatternRewrite",
+    srcs = ["AffineFullUnrollPatternRewrite.cpp"],
+    hdrs = [
+        "AffineFullUnrollPatternRewrite.h",
+        "Passes.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "Passes",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":AffineFullUnroll",
+        ":AffineFullUnrollPatternRewrite",
+        ":pass_inc_gen",
     ],
 )

--- a/lib/Transform/Affine/BUILD
+++ b/lib/Transform/Affine/BUILD
@@ -1,7 +1,32 @@
 # Passes that work with the Affine dialect
 
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=Affine",
+            ],
+            "Passes.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "AffinePasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
 )
 
 cc_library(

--- a/lib/Transform/Affine/Passes.h
+++ b/lib/Transform/Affine/Passes.h
@@ -1,0 +1,16 @@
+#ifndef LIB_TRANSFORM_AFFINE_PASSES_H_
+#define LIB_TRANSFORM_AFFINE_PASSES_H_
+
+#include "lib/Transform/Affine/AffineFullUnroll.h"
+#include "lib/Transform/Affine/AffineFullUnrollPatternRewrite.h"
+
+namespace mlir {
+namespace tutorial {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transform/Affine/Passes.h.inc"
+
+}  // namespace tutorial
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORM_AFFINE_PASSES_H_

--- a/lib/Transform/Affine/Passes.td
+++ b/lib/Transform/Affine/Passes.td
@@ -1,0 +1,22 @@
+#ifndef LIB_TRANSFORM_AFFINE_PASSES_TD_
+#define LIB_TRANSFORM_AFFINE_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def AffineFullUnroll : Pass<"affine-full-unroll"> {
+  let summary = "Fully unroll all affine loops";
+  let description = [{
+    Fully unroll all affine loops.
+  }];
+  let dependentDialects = ["mlir::affine::AffineDialect"];
+}
+
+def AffineFullUnrollPatternRewrite : Pass<"affine-full-unroll-rewrite"> {
+  let summary = "Fully unroll all affine loops using the pattern rewrite engine";
+  let description = [{
+    Fully unroll all affine loops using the pattern rewrite engine.
+  }];
+  let dependentDialects = ["mlir::affine::AffineDialect"];
+}
+
+#endif  // LIB_TRANSFORM_AFFINE_PASSES_TD_

--- a/lib/Transform/Arith/BUILD
+++ b/lib/Transform/Arith/BUILD
@@ -1,7 +1,32 @@
 # Passes that work with the Arith dialect
 
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=Arith",
+            ],
+            "Passes.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "ArithPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
 )
 
 cc_library(
@@ -9,9 +34,19 @@ cc_library(
     srcs = ["MulToAdd.cpp"],
     hdrs = ["MulToAdd.h"],
     deps = [
+        ":pass_inc_gen",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "Passes",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":MulToAdd",
+        ":pass_inc_gen",
     ],
 )

--- a/lib/Transform/Arith/MulToAdd.h
+++ b/lib/Transform/Arith/MulToAdd.h
@@ -1,26 +1,15 @@
 #ifndef LIB_TRANSFORM_ARITH_MULTOADD_H_
 #define LIB_TRANSFORM_ARITH_MULTOADD_H_
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/include/mlir/Pass/Pass.h"
+#include "mlir/Pass/Pass.h"
 
 namespace mlir {
 namespace tutorial {
 
-class MulToAddPass
-    : public PassWrapper<MulToAddPass,
-                         OperationPass<mlir::func::FuncOp>> {
-private:
-  void runOnOperation() override;
+#define GEN_PASS_DECL_MULTOADD
+#include "lib/Transform/Arith/Passes.h.inc"
 
-  StringRef getArgument() const final { return "mul-to-add"; }
+}  // namespace tutorial
+}  // namespace mlir
 
-  StringRef getDescription() const final {
-    return "Convert multiplicatoins to repeated additions";
-  }
-};
-
-} // namespace tutorial
-} // namespace mlir
-
-#endif // LIB_TRANSFORM_ARITH_MULTOADD_H_
+#endif  // LIB_TRANSFORM_ARITH_MULTOADD_H_

--- a/lib/Transform/Arith/Passes.h
+++ b/lib/Transform/Arith/Passes.h
@@ -1,0 +1,15 @@
+#ifndef LIB_TRANSFORM_ARITH_PASSES_H_
+#define LIB_TRANSFORM_ARITH_PASSES_H_
+
+#include "lib/Transform/Arith/MulToAdd.h"
+
+namespace mlir {
+namespace tutorial {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transform/Arith/Passes.h.inc"
+
+}  // namespace tutorial
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORM_ARITH_PASSES_H_

--- a/lib/Transform/Arith/Passes.td
+++ b/lib/Transform/Arith/Passes.td
@@ -1,0 +1,13 @@
+#ifndef LIB_TRANSFORM_ARITH_PASSES_TD_
+#define LIB_TRANSFORM_ARITH_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def MulToAdd : Pass<"mul-to-add"> {
+  let summary = "Convert multiplications to repeated additions";
+  let description = [{
+    Convert multiplications to repeated additions.
+  }];
+}
+
+#endif  // LIB_TRANSFORM_ARITH_PASSES_TD_

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -11,7 +11,7 @@ cc_binary(
     srcs = ["tutorial-opt.cpp"],
     includes = ["include"],
     deps = [
-        "//lib/Transform/Affine:AffineFullUnroll",
+        "//lib/Transform/Affine:Passes",
         "//lib/Transform/Arith:MulToAdd",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:MlirOptLib",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,7 +12,7 @@ cc_binary(
     includes = ["include"],
     deps = [
         "//lib/Transform/Affine:Passes",
-        "//lib/Transform/Arith:MulToAdd",
+        "//lib/Transform/Arith:Passes",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:Pass",

--- a/tools/tutorial-opt.cpp
+++ b/tools/tutorial-opt.cpp
@@ -1,4 +1,4 @@
-#include "lib/Transform/Affine/AffineFullUnroll.h"
+#include "lib/Transform/Affine/Passes.h"
 #include "lib/Transform/Arith/MulToAdd.h"
 #include "mlir/include/mlir/InitAllDialects.h"
 #include "mlir/include/mlir/Pass/PassManager.h"
@@ -9,8 +9,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);
 
-  mlir::PassRegistration<mlir::tutorial::AffineFullUnrollPass>();
-  mlir::PassRegistration<mlir::tutorial::AffineFullUnrollPassAsPatternRewrite>();
+  mlir::tutorial::registerAffinePasses();
   mlir::PassRegistration<mlir::tutorial::MulToAddPass>();
 
   return mlir::asMainReturnCode(

--- a/tools/tutorial-opt.cpp
+++ b/tools/tutorial-opt.cpp
@@ -1,5 +1,5 @@
 #include "lib/Transform/Affine/Passes.h"
-#include "lib/Transform/Arith/MulToAdd.h"
+#include "lib/Transform/Arith/Passes.h"
 #include "mlir/include/mlir/InitAllDialects.h"
 #include "mlir/include/mlir/Pass/PassManager.h"
 #include "mlir/include/mlir/Pass/PassRegistry.h"
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
   mlir::registerAllDialects(registry);
 
   mlir::tutorial::registerAffinePasses();
-  mlir::PassRegistration<mlir::tutorial::MulToAddPass>();
+  mlir::tutorial::registerArithPasses();
 
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "Tutorial Pass Driver", registry));


### PR DESCRIPTION
The new structure follows the pattern given in the official docs here: https://mlir.llvm.org/docs/PassManagement/#declarative-pass-specification