### PR TITLE
Bazel improvements

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+externals

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
-build --action_env=BAZEL_CXXOPTS=-std=c++17
-build --cxxopt='-std=c++17'
-build --host_cxxopt='-std=c++17'
-test --test_output=all
+common --action_env=BAZEL_CXXOPTS=-std=c++17
+common --cxxopt='-std=c++17'
+common --copt=-fdiagnostics-color=always
+common --test_output=errors
+common -c dbg

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ bazel-mlir-tutorial
 bazel-out
 bazel-testlogs
 
+# git submodule
+externals
+
 # cmake related files
 # ignore the user specified CMake presets in subproject directories.
 /*/CMakeUserPresets.json


### PR DESCRIPTION
A PR that makes minor improvements to the bazel build:

- use `common` for all options to that bazel doesn't reset the cache between `bazel run` and `bazel test`
- Add the git submodule added for the CMake build to the .gitignore. This is not required for git, but for any other tool that uses .gitignore to determine what files to ignore, such as ripgrep
- Add a .bazelignore to tell `bazel test ...:all` to not recurse into the git submodule subdirectory.