### PR TITLE
fix(CMakeLists.txt): Add BUILD_DEPS, change ortools's GIT_TAG main -> v9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mlir-tutorial LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(BUILD_DEPS ON)
 
 find_package(MLIR REQUIRED CONFIG)
 
@@ -28,7 +29,7 @@ include(FetchContent)
 FetchContent_Declare(
   or-tools
   GIT_REPOSITORY https://github.com/google/or-tools.git
-  GIT_TAG        main
+  GIT_TAG        v9.0
 )
 FetchContent_MakeAvailable(or-tools)
 message(STATUS "Done fetching or-tools")


### PR DESCRIPTION
fix #35 issue
- for c++17 support and build deps for whom doesn't have