### PR TITLE
fix(lib/CMakeLists.txt): change order of subdriectories build sequence

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_subdirectory(Analysis)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
+add_subdirectory(Analysis)
 add_subdirectory(Transform)


### PR DESCRIPTION
during build project with cmake below error raised.

```shell
...
[ 96%] Building CXX object lib/Analysis/ReduceNoiseAnalysis/CMakeFiles/obj.ReduceNoiseAnalysis.dir/ReduceNoiseAnalysis.cpp.o
In file included from $ROOT_DIR/mlir-tutorial/lib/Dialect/Noisy/NoisyOps.h:4,
                 from $ROOT_DIR/mlir-tutorial/lib/Analysis/ReduceNoiseAnalysis/ReduceNoiseAnalysis.cpp:5:
$ROOT_DIR/mlir-tutorial/lib/Dialect/Noisy/NoisyDialect.h:8:10: fatal error: lib/Dialect/Noisy/NoisyDialect.h.inc: No such file or directory
    #include "lib/Dialect/Noisy/NoisyDialect.h.inc"
...
```
in `lib/CMakeLists.txt`, `Analysis` should be built later than `Dialect` as it uses NoisyDialects.