### PR TITLE
Fix lit test cfg on windows.

### DIFF
--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -42,6 +42,6 @@ config.environment["PATH"] = (
 )
 
 substitutions = {
-    "%project_source_dir": runfiles_dir.joinpath(Path('mlir_tutorial')),
+    "%project_source_dir": str(runfiles_dir.joinpath(Path('mlir_tutorial'))),
 }
 config.substitutions.extend(substitutions.items())


### PR DESCRIPTION
Greetings! I'm following along your tutorial and noticed this that the test isn't working.

Without this `str()` the test would fail with a stacktrace like this:

```shell
D:\DevLLVM\repos\mlir-tutorial\tests>lit -v .\ctlz_simple.mlir
-- Testing: 1 tests, 1 workers --
UNRESOLVED: mlir_tutorial :: ctlz_simple.mlir (1 of 1)
******************** TEST 'mlir_tutorial :: ctlz_simple.mlir' FAILED ********************
Exception during script execution:
Traceback (most recent call last):
  File "C:\Wares\python310\lib\site-packages\lit\worker.py", line 76, in _execute_test_handle_errors
    result = test.config.test_format.execute(test, lit_config)
  File "C:\Wares\python310\lib\site-packages\lit\formats\shtest.py", line 29, in execute
    return lit.TestRunner.executeShTest(
  File "C:\Wares\python310\lib\site-packages\lit\TestRunner.py", line 2120, in executeShTest
    script = applySubstitutions(
  File "C:\Wares\python310\lib\site-packages\lit\TestRunner.py", line 1674, in applySubstitutions
    output.append(unescapePercents(process(line)))
  File "C:\Wares\python310\lib\site-packages\lit\TestRunner.py", line 1631, in processLine
    b = b.replace("\\", "\\\\")
TypeError: Path.replace() takes 2 positional arguments but 3 were given


********************
********************
Unresolved Tests (1):
  mlir_tutorial :: ctlz_simple.mlir


Testing Time: 0.16s
  Unresolved: 1
```

I'm only running on windows with CMake though. Not sure if this is breaking other platforms.
Cheers!

