### PR TITLE
Upgrade LLVM Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(FetchContent)
 FetchContent_Declare(
   or-tools
   GIT_REPOSITORY https://github.com/google/or-tools.git
-  GIT_TAG        v9.0
+  GIT_TAG        v9.11
 )
 FetchContent_MakeAvailable(or-tools)
 message(STATUS "Done fetching or-tools")

--- a/bazel/import_llvm.bzl
+++ b/bazel/import_llvm.bzl
@@ -8,8 +8,8 @@ load(
 def import_llvm(name):
     """Imports LLVM."""
 
-    # 2024-09-28
-    LLVM_COMMIT = "29b92d07746fac26cd64c914bc9c5c3833974f6d"
+    # 2025-02-01
+    LLVM_COMMIT = "16d4453f2f5d9554ce39507fda0f33ce9066007b"
 
     new_git_repository(
         name = name,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,7 +13,7 @@ filegroup(
         "@llvm-project//llvm:count",
         "@llvm-project//llvm:llc",
         "@llvm-project//llvm:not",
-        "@llvm-project//mlir:mlir-cpu-runner",
+        "@llvm-project//mlir:mlir-runner",
         "@llvm-project//mlir:mlir-opt",
         "@llvm-project//mlir:mlir-translate",
         "@mlir_tutorial_pip_deps_lit//:pkg",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ configure_lit_site_cfg(
 set (MLIR_TUTORIAL_TEST_DEPENDS
     FileCheck count not
     mlir-opt
-    mlir-cpu-runner
+    mlir-runner
     # tutorial-opt
 )
 

--- a/tests/ctlz_runner.mlir
+++ b/tests/ctlz_runner.mlir
@@ -5,7 +5,7 @@
 // RUN:      convert-func-to-llvm, \
 // RUN:      convert-cf-to-llvm, \
 // RUN:      reconcile-unrealized-casts)" \
-// RUN: | mlir-cpu-runner -e test_7i32_to_29 -entry-point-result=i32 > %t
+// RUN: | mlir-runner -e test_7i32_to_29 -entry-point-result=i32 > %t
 // RUN: FileCheck %s --check-prefix=CHECK_TEST_7i32_TO_29 < %t
 
 func.func @test_7i32_to_29() -> i32 {
@@ -23,7 +23,7 @@ func.func @test_7i32_to_29() -> i32 {
 // RUN:      convert-func-to-llvm, \
 // RUN:      convert-cf-to-llvm, \
 // RUN:      reconcile-unrealized-casts)" \
-// RUN: | mlir-cpu-runner -e test_7i64_to_61 -entry-point-result=i64 > %t
+// RUN: | mlir-runner -e test_7i64_to_61 -entry-point-result=i64 > %t
 // RUN:  FileCheck %s --check-prefix=CHECK_TEST_7i64_TO_61 < %t
 func.func @test_7i64_to_61() -> i64 {
   %arg = arith.constant 7 : i64

--- a/tests/lit.cmake.cfg.py
+++ b/tests/lit.cmake.cfg.py
@@ -46,7 +46,7 @@ llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 tool_dirs = [config.project_tools_dir, config.llvm_tools_dir]
 tools = [
     "mlir-opt",
-    "mlir-cpu-runner",
+    "mlir-runner",
     "tutorial-opt"
 ]
 


### PR DESCRIPTION
Addresses #45

This PR introduces changes that were required to run tutorials on MacOS 12.7.6 with latest LLVM build (as of 2025-01-22).